### PR TITLE
fix(cors): If there is no Access-Control-Request-Headers, the preflig…

### DIFF
--- a/src/main/java/io/gravitee/policy/cors/CorsPolicy.java
+++ b/src/main/java/io/gravitee/policy/cors/CorsPolicy.java
@@ -101,7 +101,7 @@ public class CorsPolicy {
 
     private boolean isRequestHeadersValid(String accessControlRequestHeaders) {
         String [] headers = splitAndTrim(accessControlRequestHeaders, ",");
-        return containsAll(configuration.getAccessControlAllowHeaders(), headers);
+        return headers != null && containsAll(configuration.getAccessControlAllowHeaders(), headers);
     }
 
     private boolean isRequestMethodsValid(String accessControlRequestMethods) {


### PR DESCRIPTION
…ht request is considered as invalid

Closes gravitee-io/issues#195
