### PR TITLE
fix(cors): Stream handler is not associated to the correct incoming r…

### DIFF
--- a/src/main/java/io/gravitee/policy/cors/CorsPolicy.java
+++ b/src/main/java/io/gravitee/policy/cors/CorsPolicy.java
@@ -174,7 +174,7 @@ public class CorsPolicy {
         public Request invoke(ExecutionContext executionContext, Request serverRequest, ReadStream<Buffer> stream, Handler<ProxyConnection> connectionHandler) {
             final ProxyConnection proxyConnection = new PreflightProxyConnection(serverRequest);
 
-            serverRequest
+            stream
                     .bodyHandler(proxyConnection::write)
                     .endHandler(endResult -> proxyConnection.end());
 


### PR DESCRIPTION
…equest stream

Closes gravitee-io/issues#880